### PR TITLE
Return DidLike in any public contribution response data

### DIFF
--- a/Server.Application/Common/Dtos/Content/PublicContribution/PublicContributionInListDto.cs
+++ b/Server.Application/Common/Dtos/Content/PublicContribution/PublicContributionInListDto.cs
@@ -21,6 +21,7 @@ public class PublicContributionInListDto
     public string? ShortDescription { get; set; }
     public string? Avatar { get; set; }
     public string? WhoApproved { get; set; }
+    public bool DidLike { get; set; } = false;
 
     public string? Status { get; set; } = ContributionStatus.Approve.ToStringValue();
 }

--- a/Server.Application/Features/PublicContributionApp/Queries/GetAllPublicContributionsPagination/GetAllPublicContributionsPaginationQueryHandler.cs
+++ b/Server.Application/Features/PublicContributionApp/Queries/GetAllPublicContributionsPagination/GetAllPublicContributionsPaginationQueryHandler.cs
@@ -47,6 +47,11 @@ public class GetAllPublicContributionsPaginationQueryHandler : IRequestHandler<G
             allowedGuest: request.AllowedGuest
         );
 
+        foreach (var item in result.Results)
+        {
+            item.DidLike = await _unitOfWork.LikeRepository.AlreadyLike(item.Id, user.Id);
+        }
+
         return new ResponseWrapper<PaginationResult<PublicContributionInListDto>>
         {
             IsSuccessful = true,

--- a/Server.Application/Features/PublicContributionApp/Queries/GetPublicContributionBySlug/GetPublicContributionBySlugQueryHandler.cs
+++ b/Server.Application/Features/PublicContributionApp/Queries/GetPublicContributionBySlug/GetPublicContributionBySlugQueryHandler.cs
@@ -51,6 +51,7 @@ public class GetPublicContributionBySlugQueryHandler : IRequestHandler<GetPublic
 
         publicContribution.Views += 1;
         publicContributionDto.View = publicContribution.Views;
+        publicContributionDto.DidLike = await _unitOfWork.LikeRepository.AlreadyLike(publicContributionDto.Id, user.Id);
 
         await _unitOfWork.CompleteAsync();
 


### PR DESCRIPTION
- return DidLike for in the public contribution dto because reduce the workload for Frontend to query many at the same time such as: query the public contribution and query the like of the user and then compare both of it.